### PR TITLE
add riscv64 binary release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,11 @@ builds:
       - linux
       - freebsd
       - darwin
+    goarch:
+      - amd64
+      - arm
+      - arm64
+      - riscv64
     ldflags:
       - -s -w
       - -X go.ntppool.org/common/version.VERSION={{.Version}}

--- a/cmd/ntppool-agent/README.md
+++ b/cmd/ntppool-agent/README.md
@@ -10,7 +10,7 @@ there.
 ## Installation
 
 The monitor is supported on Linux and FreeBSD. Yum and deb package
-repositories are available for i386, arm64 and amd64. For repository
+repositories are available for i386, arm64, amd64 and riscv64. For repository
 instructions see https://builds.ntppool.dev/repo/
 
 ## Setup


### PR DESCRIPTION
I've tested and runs on my orangepirv2 for couple of weeks, it works fine.