### PR TITLE
Add further NTP daemons deb package accepts as dependency

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -91,7 +91,7 @@ nfpms:
     overrides:
       deb:
         dependencies:
-          - "ntp | chrony"
+          - "ntp | chrony | ntpsec | ntpd-rs"
 
       rpm:
         # this is supposed to work, but I couldn't figure it out.


### PR DESCRIPTION
The `ntp` package in current stable Debian and recent Ubuntu versions is a metapackage only to pull in `ntpsec`, so mention the latter explicitly as well in preparation for when `ntp` will be dropped completely.

`ntpd-rs` is maturing from timekeeping perspective, so add as well to allow coexistence with `ntppool-agent`.