### PR TITLE
Allow giving work to monitors without prior scores

### DIFF
--- a/ntpdb/query.sql.go
+++ b/ntpdb/query.sql.go
@@ -592,9 +592,8 @@ const getServers = `-- name: GetServers :many
 SELECT s.id, s.ip, s.ip_version, s.user_id, s.account_id, s.hostname, s.stratum, s.in_pool, s.in_server_list, s.netspeed, s.netspeed_target, s.created_on, s.updated_on, s.score_ts, s.score_raw, s.deletion_on, s.flags
     FROM servers s
     LEFT JOIN server_scores ss
-        ON (s.id=ss.server_id)
-WHERE (monitor_id = ?
-    AND s.ip_version = ?
+        ON (s.id = ss.server_id AND ss.monitor_id = ?)
+WHERE s.ip_version = ?
     AND (ss.queue_ts IS NULL
           OR (ss.score_raw > -90 AND ss.status = "active"
                AND ss.queue_ts < DATE_SUB( NOW(), INTERVAL ? second))
@@ -603,7 +602,7 @@ WHERE (monitor_id = ?
           OR (ss.queue_ts < DATE_SUB( NOW(), INTERVAL 120 minute)))
     AND (s.score_ts IS NULL OR
         (s.score_ts < DATE_SUB( NOW(), INTERVAL ? second) ))
-    AND (deletion_on IS NULL or deletion_on > NOW()))
+    AND (deletion_on IS NULL or deletion_on > NOW())
 ORDER BY ss.queue_ts
 LIMIT  ?
 OFFSET ?

--- a/query.sql
+++ b/query.sql
@@ -189,9 +189,8 @@ INSERT INTO log_scores
 SELECT s.*
     FROM servers s
     LEFT JOIN server_scores ss
-        ON (s.id=ss.server_id)
-WHERE (monitor_id = sqlc.arg('monitor_id')
-    AND s.ip_version = sqlc.arg('ip_version')
+        ON (s.id = ss.server_id AND ss.monitor_id = sqlc.arg('monitor_id'))
+WHERE s.ip_version = sqlc.arg('ip_version')
     AND (ss.queue_ts IS NULL
           OR (ss.score_raw > -90 AND ss.status = "active"
                AND ss.queue_ts < DATE_SUB( NOW(), INTERVAL sqlc.arg('interval_seconds') second))
@@ -200,7 +199,7 @@ WHERE (monitor_id = sqlc.arg('monitor_id')
           OR (ss.queue_ts < DATE_SUB( NOW(), INTERVAL 120 minute)))
     AND (s.score_ts IS NULL OR
         (s.score_ts < DATE_SUB( NOW(), INTERVAL sqlc.arg('interval_seconds_all') second) ))
-    AND (deletion_on IS NULL or deletion_on > NOW()))
+    AND (deletion_on IS NULL OR deletion_on > NOW())
 ORDER BY ss.queue_ts
 LIMIT  ?
 OFFSET ?;


### PR DESCRIPTION
GetServers is used for selecting which NTP servers are assigned to be checked by a monitor server. Due to the current SQL query, only those NTP servers which have a prior measurement from a particular monitor can be selected. This change lifts this restriction.